### PR TITLE
Update micrometer-core version to 1.3.3; other dependencies - to actual versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Update micrometer-core version to 1.3.3
+
 ## [0.4.0] - 2020-01-09
 - Append library-identifying string to HTTP `User-Agent` header as suffix
 - Add ability to enable "audit logging" for more verbose troubleshooting

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,19 +31,15 @@ googleJavaFormat {
 }
 
 dependencies {
-    api("io.micrometer:micrometer-core:1.2.2")
+    api("io.micrometer:micrometer-core:1.3.3")
     api("com.newrelic.telemetry:telemetry:0.3.4")
-    //note: these are transitive dependencies from micrometer, but needed to be upgraded due to a security vulnerability
-    implementation("com.fasterxml.jackson.core:jackson-core:2.9.9")
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.9.9")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.9.10.1")
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
-    testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.2")
-    testImplementation("org.mockito:mockito-core:3.0.0")
-    testImplementation("org.mockito:mockito-junit-jupiter:3.0.0")
-    testImplementation("org.mock-server:mockserver-netty:5.7.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0")
+    testRuntimeOnly("org.slf4j:slf4j-simple:1.7.30")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
+    testImplementation("org.mockito:mockito-core:3.2.4")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.2.4")
+    testImplementation("org.mock-server:mockserver-netty:5.9.0")
 }
 
 val jar: Jar by tasks


### PR DESCRIPTION
Update `micrometer-core` to the latest stable version 1.3.3 .

Other dependencies updated to the actual version too.

Explicit update of the following micrometer transitive dependencies no more required:
``` 
implementation("com.fasterxml.jackson.core:jackson-core:2.9.9")
implementation("com.fasterxml.jackson.core:jackson-annotations:2.9.9")
implementation("com.fasterxml.jackson.core:jackson-databind:2.9.10.1")
```

The latest `micrometer-core` already contains jackson-core with vulnerability fixes:

```bash
$ ./gradlew dependencies | grep -A 4 jackson-core:2.10.1                
     |    |    +--- com.fasterxml.jackson.core:jackson-core:2.10.1
     |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.10.1
     |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.10.1
    ...
```