### PR TITLE
'Find data' section addition from docs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ The project uses gradle 5 for building, and the gradle wrapper is provided.
 To compile, run the tests and build the jar:
 
 `$ ./gradlew build`
+
+### Find and use your data
+
+For tips on how to find and query your data, see [Find metric data](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data).
+
+For general querying information, see:
+- [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
+- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions)
+


### PR DESCRIPTION
This PR is to add a ‘how to find data’ section so that customers can find the data they send. I’ve included what I think are the applicable data types (Metric object data) but let me know if there are other data types reported by this exporter. If you think this exporter will change to send other types of data in future, keep in mind it will be important to update this with a link to that data type.