### PR TITLE
update the changelog and version for 0.6.0.  upgrade to latest sdk.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - TBD (unreleased)
+## [0.6.0] - TBD (unreleased)
+- **BREAKING CHANGE**: [Repackage](https://github.com/newrelic/micrometer-registry-newrelic/pull/104) registry class to `com.newrelic.telemetry.micrometer.NewRelicRegistry`.
+  Users will need to change code or configuration that references the old package.
+- Shut down the telemetry sdk in [`close()`](https://github.com/newrelic/micrometer-registry-newrelic/pull/82/)
+  in order to flush the last batch of telemetry. 
 - Depend directly on slf4j
-- Update to New Relic Telemetry SDK 0.6.1
-- Change construction of NewRelicRegistry to avoid deprecations in the SDK.
-- Endpoint URI overrides will now respect path information (it was previously ignored). 
+- Change [construction of NewRelicRegistry](https://github.com/newrelic/micrometer-registry-newrelic/pull/85) to avoid deprecations in the SDK.
+- Endpoint URI overrides will now respect path information (it was previously ignored).
+- Upgrade to micrometer-core 1.5.4
+- Update to New Relic Telemetry SDK 0.9.0
 
 ## [0.5.0] - 2020-04-01
 - Changed: Update micrometer-core version to 1.3.3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ googleJavaFormat {
 
 dependencies {
     api("io.micrometer:micrometer-core:1.5.4")
-    api("com.newrelic.telemetry:telemetry:0.7.0")
+    api("com.newrelic.telemetry:telemetry:0.9.0")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testImplementation("org.mockito:mockito-core:3.2.4")
     testImplementation("org.mockito:mockito-junit-jupiter:3.2.4")
-    testImplementation("org.mock-server:mockserver-netty:5.10.0")
+    testImplementation("org.mock-server:mockserver-netty:5.11.1")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion = 0.5.1
+releaseVersion = 0.6.0
 
 # set this to true to enable using a local sonatype (for debugging publishing issues)
 # (start a local sonatype in docker with this command: $ docker run -d -p 8081:8081 --name nexus sonatype/nexus3)


### PR DESCRIPTION
We haven't done a release since April, and users would like some of the past updates, so let's cut a release soon.

I wasn't sure why we had 0.5.1 going, but enough time has passed that I think v0.6.0 is warranted.