### PR TITLE
Update 'micrometer-core' and 'telemetry' to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.7.0] - TBD
-- TBD
+- Update io.micrometer:micrometer-core to 1.6.3
+- Update com.newrelic.telemetry:telemetry to 0.10.0
 
 ## [0.6.0] - 2020-10-27
 - **BREAKING CHANGE**: [Repackage](https://github.com/newrelic/micrometer-registry-newrelic/pull/104) registry class to `com.newrelic.telemetry.micrometer.NewRelicRegistry`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,8 @@ googleJavaFormat {
 }
 
 dependencies {
-    api("io.micrometer:micrometer-core:1.5.4")
-    api("com.newrelic.telemetry:telemetry:0.9.0")
+    api("io.micrometer:micrometer-core:1.6.3")
+    api("com.newrelic.telemetry:telemetry:0.10.0")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0")

--- a/src/main/java/com/newrelic/telemetry/micrometer/NewRelicRegistry.java
+++ b/src/main/java/com/newrelic/telemetry/micrometer/NewRelicRegistry.java
@@ -284,10 +284,7 @@ public class NewRelicRegistry extends StepMeterRegistry {
       }
       try {
         URI uri = URI.create(config.uri());
-        if (uri.getPath() != null && uri.getPath().length() > 0) {
-          return builder.endpointWithPath(uri.toURL());
-        }
-        return builder.endpoint(uri.getScheme(), uri.getHost(), uri.getPort());
+        return builder.endpoint(uri.toURL());
       } catch (MalformedURLException e) {
         throw new RuntimeException("Invalid URI for the metric API : " + config.uri(), e);
       }


### PR DESCRIPTION
Let's update these API dependencies to latest versions:
- io.micrometer:micrometer-core to 1.6.3
- com.newrelic.telemetry:telemetry to 0.10.0