### PR TITLE
upgrade for snyk issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,13 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testImplementation("org.mockito:mockito-core:3.2.4")
     testImplementation("org.mockito:mockito-junit-jupiter:3.2.4")
-    testImplementation("org.mock-server:mockserver-netty:5.11.1")
+    testImplementation("org.mock-server:mockserver-netty:5.11.2")
+    constraints {
+        testImplementation("org.apache.httpcomponents:httpclient:4.5.13") {
+            because("previous versions trigger Snyk security warnings")
+        }
+    }
+
 }
 
 java {


### PR DESCRIPTION
[This snyk failure](https://github.com/newrelic/micrometer-registry-newrelic/actions/runs/483784496
) is because mock server needs to be updated. After the update, the mock server is still using a httpclient that has issues so I'm forcing the dependency to a patched version. 

After this update, there will still be one more snyk issue that has no resolution right now and it is in a test dependency. 