### PR TITLE
Allow registry to use BatchDataSender with useLicenseKey enabled

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ googleJavaFormat {
 
 dependencies {
     api("io.micrometer:micrometer-core:1.6.4")
-    api("com.newrelic.telemetry:telemetry-core:0.11.0")
+    api("com.newrelic.telemetry:telemetry-core:0.12.0")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0")

--- a/src/main/java/com/newrelic/telemetry/micrometer/NewRelicRegistry.java
+++ b/src/main/java/com/newrelic/telemetry/micrometer/NewRelicRegistry.java
@@ -270,6 +270,7 @@ public class NewRelicRegistry extends StepMeterRegistry {
       SenderConfiguration.SenderConfigurationBuilder builder =
           MetricBatchSender.configurationBuilder()
               .apiKey(config.apiKey())
+              .useLicenseKey(config.useLicenseKey())
               .httpPoster(new MicrometerHttpPoster(httpSender))
               .secondaryUserAgent("NewRelic-Micrometer-Exporter/" + implementationVersion)
               .auditLoggingEnabled(config.enableAuditMode());

--- a/src/main/java/com/newrelic/telemetry/micrometer/NewRelicRegistryConfig.java
+++ b/src/main/java/com/newrelic/telemetry/micrometer/NewRelicRegistryConfig.java
@@ -52,4 +52,15 @@ public interface NewRelicRegistryConfig extends StepRegistryConfig {
   default boolean enableAuditMode() {
     return false;
   }
+
+  /**
+   * Configure the underlying New Relic Telemetry SDK to consider the apiKey to be a license key,
+   * not an insights api key.
+   *
+   * @see com.newrelic.telemetry.transport.BatchDataSender
+   * @return true if configured apiKey is a license key, not an insights api key.
+   */
+  default boolean useLicenseKey() {
+    return false;
+  }
 }


### PR DESCRIPTION
* Add option to `NewRelicRegistryConfig`, to enable `useLicenseKey` option in `BatchDataSender` (com.newrelic.telemetry.SenderConfiguration.SenderConfigurationBuilder#useLicenseKey)
* Bump com.newrelic.telemetry:telemetry-core to 0.12.0

This is essential for us to be able to automatically configure micrometer metrics via terraform, as it is not possible to provision an Insights Insert Key via any NewRelic API