### PR TITLE
change snyk to monitor

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,4 +10,4 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          command: test
+          command: monitor

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
         testImplementation("org.apache.velocity:velocity-engine-core:2.3") {
             because ("snyk violations")
         }
+        testImplementation("net.minidev:json-smart:2.4.1") {
+            because ("snyk violations")
+        }
     }
 
 }


### PR DESCRIPTION
After talking with Snyk,  this was proposed as a solution to our dependencies being out of date between the repo and the UI. Local testing with Act seems to have updated the dependencies correctly, snyk test passed